### PR TITLE
Strict Equality & CleanUp

### DIFF
--- a/server.js
+++ b/server.js
@@ -14,7 +14,7 @@ const MONGODB_URI = process.env.MONGODB_URI
 // const UPLOADS_DIR = process.env.UPLOADS_DIR
 // const PUBLIC_DIR = path.join(__dirname, process.env.PUBLIC_DIR)
 
-let app = express()
+const app = express()
 
 const server = http.createServer(app)
 
@@ -22,15 +22,10 @@ const server = http.createServer(app)
 
 // global.io = io
 
-mongoose.connect(MONGODB_URI, {
-  useNewUrlParser: true,
-  useUnifiedTopology: true,
-  useFindAndModify: false,
-  useCreateIndex: true
-})
+mongoose.connect(MONGODB_URI)
 mongoose.Promise = global.Promise
 
-let db = mongoose.connection
+const db = mongoose.connection
 db.on('error', console.error.bind(console, 'MongoDB connection error:'))
 
 if (process.env.NODE_ENV === 'development') {
@@ -93,5 +88,5 @@ app.use('/', require('./routes'))
 
 server.listen(PORT, err => {
   if (err) throw err
-  console.info('Listening on port ' + PORT + '...')
+  console.info(`Listening on port ${PORT}...`)
 })

--- a/utils/mkdirSync.js
+++ b/utils/mkdirSync.js
@@ -2,11 +2,10 @@ const fs = require('fs')
 const path = require('path')
 
 const mkdirSync = dirpath => {
-  // console.log('Creating directories...')
-  // console.log(typeof dirpath)
+
 
   try {
-    if (typeof dirpath == 'string') makedirForReal(dirpath)
+    if (typeof dirpath === 'string') makedirForReal(dirpath)
     else dirpath.forEach(makedirForReal)
     return dirpath
   } catch (err) {
@@ -15,8 +14,8 @@ const mkdirSync = dirpath => {
 }
 
 const makedirForReal = dir => {
-  let dir_path = path.join(__dirname, '..', dir)
-  // console.log(dir_path)
+  const dir_path = path.join(__dirname, '..', dir)
+
 
   if (!fs.existsSync(dir_path)) {
     fs.mkdirSync(dir_path, {

--- a/utils/unlinkSync.js
+++ b/utils/unlinkSync.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 
 const unlinkSync = filepath => {
   try {
-    if (typeof filepath == 'string') unlinkForReal(filepath)
+    if (typeof filepath === 'string') unlinkForReal(filepath)
     else filepath.forEach(unlinkForReal)
     return filepath
   } catch (err) {
@@ -11,7 +11,7 @@ const unlinkSync = filepath => {
 }
 
 const unlinkForReal = file => {
-  // console.log(file, fs.existsSync(file))
+
   if (fs.existsSync(file)) fs.unlinkSync(file)
 }
 


### PR DESCRIPTION
## Issue 

- Used non-strict equality (==) which could cause unexpected behaviour due to type coercion.
- Variables were declared with let even though they were never reassigned.

## Changes i made 

- Replaced loose equality checks (==) with strict equality (===) to ensure safer type comparisons.
- Updated variable declarations from let to const where reassignment was not required.
